### PR TITLE
🔒 Add redirection to auth0 when signIn

### DIFF
--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -133,7 +133,7 @@ const SessionComponent = () => {
   return (
     <div className="flex flex-col gap-4 rounded bg-white p-4 text-lg font-medium text-[#323232] sm:w-1/3">
       Not signed in <br />
-      <button onClick={() => void signIn()}>Log in</button>
+      <button onClick={() => void signIn("auth0")}>Log in</button>
     </div>
   );
 };


### PR DESCRIPTION
**Description of the Change**
Add redirection to auth0 _automagically_ when signIn

**Quantitative Performance Benefits**
Improve the user experience by not doing unnecessary things.

**Possible Drawbacks**
Use is limited to a single provider. It's OK for now.

**Verification Process**
Go to account and click Log in. The intermediate screen with the list of providers should no longer be visible.

Localhost
OK

Preview
Not working maybe because the domain is not authorized in Auth0, it must be authorized in the admin console, however I don't have access as it needs 2FA Auth.
<img width="591" alt="image" src="https://github.com/iTjuana/itj-library/assets/4336126/32508a00-f219-4343-a3ec-e6d74071547e">

